### PR TITLE
update jobspec for experimental types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ exp2: build
 	$(COMMONENVVAR) $(BUILDENVVAR) go build -ldflags '-w' -o ./examples/experimental/bin/example2 examples/experimental/example2/example.go
 
 .PHONY: test
-test:
+test: all
 	./examples/v1/bin/example1
 	./examples/v1/bin/example2
 	./examples/v1/bin/example3

--- a/examples/experimental/example1/example.go
+++ b/examples/experimental/example1/example.go
@@ -12,7 +12,7 @@ func main() {
 	fmt.Println("This example reads, parses, and validates a Jobspec")
 
 	// Assumes running from the root
-	fileName := flag.String("json", "examples/v1/example1/jobspec.yaml", "yaml file")
+	fileName := flag.String("json", "examples/experimental/example1/jobspec.yaml", "yaml file")
 	flag.Parse()
 
 	yamlFile := *fileName

--- a/examples/experimental/example1/jobspec.yaml
+++ b/examples/experimental/example1/jobspec.yaml
@@ -9,8 +9,9 @@ resources:
         with:
           - type: core
             count: 2
-tasks:
-- command:
+task:
+  slot: "default"
+  command:
   - ior
   count:
     per_slot: 1

--- a/examples/experimental/example2/example.go
+++ b/examples/experimental/example2/example.go
@@ -12,7 +12,7 @@ func main() {
 	fmt.Println("This example reads, parses, and validates a Jobspec")
 
 	// Assumes running from the root
-	fileName := flag.String("json", "examples/v1/example2/jobspec.yaml", "yaml file")
+	fileName := flag.String("json", "examples/experimental/example2/jobspec.yaml", "yaml file")
 	flag.Parse()
 
 	yamlFile := *fileName

--- a/examples/experimental/example2/jobspec.yaml
+++ b/examples/experimental/example2/jobspec.yaml
@@ -9,22 +9,25 @@ resources:
         with:
           - type: core
             count: 2
-tasks:
-- count:
+task:
+  slot: "default"
+  count:
     per_slot: 1
-  script: |
-    #!/bin/bash
-    start_fractal() {
-      sleep 5
-      curl -X POST http://localhost:9092/start       
-     }
-     echo "This is task \${FLUX_TASK_RANK}"
-     if [[ "\${FLUX_TASK_RANK}" == "0" ]]; then
-       start_fractal &
-       fractal leader --host 0.0.0.0:50051 --force-exit
-     else
-       fractal worker --host flux-sample-0.flux-service.default.svc.cluster.local:50051
-     fi    
+  scripts: 
+    - name: "job.sh"
+      content: |
+        #!/bin/bash
+        start_fractal() {
+          sleep 5
+          curl -X POST http://localhost:9092/start       
+         }
+         echo "This is task \${FLUX_TASK_RANK}"
+         if [[ "\${FLUX_TASK_RANK}" == "0" ]]; then
+           start_fractal &
+           fractal leader --host 0.0.0.0:50051 --force-exit
+         else
+           fractal worker --host flux-sample-0.flux-service.default.svc.cluster.local:50051
+         fi    
   resources:
     io:
       storage:

--- a/pkg/jobspec/experimental/convert.go
+++ b/pkg/jobspec/experimental/convert.go
@@ -50,12 +50,11 @@ func NewSimpleJobspec(name, command string, nodes, tasks int32) (*Jobspec, error
 	// Tasks reference the slot and command
 	// Note: if we need better split can use "github.com/google/shlex"
 	cmd := strings.Split(command, " ")
-	taskResource := []Tasks{
-		{
-			Command: cmd,
-			Slot:    name,
-			Count:   Count{PerSlot: int32(1)},
-		}}
+	taskResource := Task{
+		Command: cmd,
+		Slot:    name,
+		Count:   Count{PerSlot: int32(1)},
+	}
 
 	// Attributes are for the system, we aren't going to add them yet
 	// attributes:
@@ -68,6 +67,6 @@ func NewSimpleJobspec(name, command string, nodes, tasks int32) (*Jobspec, error
 	return &Jobspec{
 		Version:   jobspecVersion,
 		Resources: []Resource{nodeResource},
-		Tasks:     taskResource,
+		Task:      taskResource,
 	}, nil
 }

--- a/pkg/jobspec/experimental/jobspec.go
+++ b/pkg/jobspec/experimental/jobspec.go
@@ -64,13 +64,9 @@ func (js *Jobspec) GetJobName() string {
 	// If we have tasks, we can get from the command
 	// This entire set of checks is meant to be conservative
 	// and avoid any errors with nil / empty arrays, etc.
-	if js.Tasks != nil {
-		if len(js.Tasks) > 0 {
-			command := js.Tasks[0].Command
-			if len(command) > 0 {
-				name = command[0]
-			}
-		}
+	command := js.Task.Command
+	if len(command) > 0 {
+		name = command[0]
 	}
 	return name
 }

--- a/pkg/jobspec/experimental/schema.json
+++ b/pkg/jobspec/experimental/schema.json
@@ -1,133 +1,240 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_24/schema.json",
-    "title": "jobspec-01",
-  
-    "description":         "Flux jobspec version 1",
-  
-    "definitions": {
-      "intranode_resource_vertex": {
-        "description": "schema for resource vertices within a node, cannot have child vertices",
-        "type": "object",
-        "required": ["type", "count"],
-        "properties": {
-          "type": { "enum": ["core", "gpu"]},
-          "count": { "type": "integer", "minimum" : 1 },
-          "unit": { "type": "string" }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://github.com/flux-framework/rfc/tree/master/data/spec_24/schema.json",
+  "title": "jobspec-01",
+  "description": "Flux jobspec version 1",
+  "definitions": {
+    "intranode_resource_vertex": {
+      "description": "schema for resource vertices within a node, cannot have child vertices",
+      "type": "object",
+      "required": [
+        "type",
+        "count"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "core",
+            "gpu"
+          ]
         },
-        "additionalProperties": false
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "unit": {
+          "type": "string"
+        }
       },
-      "node_vertex": {
-        "description": "schema for the node resource vertex",
-        "type": "object",
-        "required": ["type", "count", "with"],
-        "properties": {
-          "type": { "enum" : ["node"] },
-          "count": { "type": "integer", "minimum" : 1 },
-          "unit": { "type": "string" },
-          "with": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
-            "items": {
-              "oneOf": [
-                {"$ref": "#/definitions/slot_vertex"}
-              ]
-            }
-          }
+      "additionalProperties": false
+    },
+    "node_vertex": {
+      "description": "schema for the node resource vertex",
+      "type": "object",
+      "required": [
+        "type",
+        "count",
+        "with"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "node"
+          ]
         },
-        "additionalProperties": false
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "unit": {
+          "type": "string"
+        },
+        "with": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/slot_vertex"
+              }
+            ]
+          }
+        }
       },
-      "slot_vertex": {
-        "description": "special slot resource type - label assigns to task slot",
-        "type": "object",
-        "required": ["type", "count", "with", "label"],
-        "properties": {
-          "type": { "enum" : ["slot"] },
-          "count": { "type": "integer", "minimum" : 1 },
-          "unit": { "type": "string" },
-          "label": { "type": "string" },
-          "exclusive": { "type": "boolean" },
-          "with": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 2,
-            "items": {
-              "oneOf": [
-                {"$ref": "#/definitions/intranode_resource_vertex"}
-              ]
-            }
-          }
+      "additionalProperties": false
+    },
+    "slot_vertex": {
+      "description": "special slot resource type - label assigns to task slot",
+      "type": "object",
+      "required": [
+        "type",
+        "count",
+        "with",
+        "label"
+      ],
+      "properties": {
+        "type": {
+          "enum": [
+            "slot"
+          ]
         },
-        "additionalProperties": false
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "unit": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "exclusive": {
+          "type": "boolean"
+        },
+        "with": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 2,
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/intranode_resource_vertex"
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "type": "object",
+  "required": [
+    "version",
+    "resources",
+    "task"
+  ],
+  "properties": {
+    "version": {
+      "description": "the jobspec version",
+      "type": "integer",
+      "enum": [
+        1
+      ]
+    },
+    "resources": {
+      "description": "requested resources",
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/node_vertex"
+          },
+          {
+            "$ref": "#/definitions/slot_vertex"
+          }
+        ]
       }
     },
-    "type": "object",
-    "required": ["version", "resources", "attributes", "tasks"],
-    "properties": {
-      "version": {
-        "description": "the jobspec version",
-        "type": "integer",
-        "enum": [1]
-      },
-      "resources": {
-        "description": "requested resources",
-        "type": "array",
-        "minItems": 1,
-        "maxItems": 1,
-        "items": {
-          "oneOf": [
-            { "$ref": "#/definitions/node_vertex" },
-            { "$ref": "#/definitions/slot_vertex" }
-          ]
-        }
-      },
-      "attributes": {
-        "description": "system and user attributes",
-        "type": ["object", "null"],
-        "properties": {
-          "system": {
-            "type": "object",
-            "properties": {
-              "duration": { "type": "number", "minimum": 0 },
-              "cwd": { "type": "string" },
-              "environment": { "type": "object" }
+    "attributes": {
+      "description": "system and user attributes",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "system": {
+          "type": "object",
+          "properties": {
+            "duration": {
+              "type": "number",
+              "minimum": 0
+            },
+            "cwd": {
+              "type": "string"
+            },
+            "environment": {
+              "type": "object"
             }
-          },
-          "user": {
-            "type": "object"
           }
         },
-        "additionalProperties": false
+        "user": {
+          "type": "object"
+        }
       },
-      "tasks": {
-        "description": "task configuration",
-        "type": "array",
-        "maxItems": 1,
-        "items": {
-          "type": "object",
-          "required": ["slot", "count" ],
-          "properties": {
-            "command": {
-              "type": ["string", "array"],
-              "minItems": 1,
-              "items": { "type": "string" }
-            },
-            "resources": { "type": "object" },
-            "batch": { "type": "string" },
-            "script": { "type": "string" },
-            "slot": { "type": "string" },
-            "count": {
+      "additionalProperties": false
+    },
+    "task": {
+      "description": "task configuration",
+      "type": "object",
+      "required": [
+        "slot",
+        "count"
+      ],
+      "properties": {
+        "command": {
+          "type": [
+            "string",
+            "array"
+          ],
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "transform": {
+          "type": ["array"],
+          "minItems": 1,
+          "items": {
               "type": "object",
-              "additionalProperties": false,
               "properties": {
-                "per_slot": { "type": "integer", "minimum" : 1 },
-                "total": { "type": "integer", "minimum" : 1 }
+                  "step": {"type": "string"}
+              },
+              "required": ["step"]
+          }
+        },
+        "scripts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "content"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "content": {
+                "type": "string"
               }
             }
-          },
-          "additionalProperties": false
+          }
+        },
+        "slot": {
+          "type": "string"
+        },
+        "count": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "per_slot": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "total": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
+}

--- a/pkg/jobspec/experimental/types.go
+++ b/pkg/jobspec/experimental/types.go
@@ -7,17 +7,22 @@ var (
 type Jobspec struct {
 	Version    int        `json:"version" yaml:"version"`
 	Resources  []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
-	Tasks      []Tasks    `json:"tasks,omitempty" yaml:"tasks,omitempty"`
+	Task       Task       `json:"task,omitempty" yaml:"task,omitempty"`
 	Attributes Attributes `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 }
 
-type Tasks struct {
+type Task struct {
 	Command   []string               `json:"command,omitempty" yaml:"command,omitempty"`
 	Slot      string                 `json:"slot,omitempty" yaml:"slot,omitempty"`
 	Count     Count                  `json:"count,omitempty" yaml:"count,omitempty"`
 	Resources map[string]interface{} `json:"resources,omitempty" yaml:"resources,omitempty"`
-	Script    string                 `json:"script,omitempty" yaml:"script,omitempty"`
-	Batch     string                 `json:"batch,omitempty" yaml:"batch,omitempty"`
+	Scripts   []Script               `json:"scripts,omitempty" yaml:"scripts,omitempty"`
+	Transform []interface{}          `json:"transform,omitempty" yaml:"transform,omitempty"`
+}
+
+type Script struct {
+	Name    string `json:"name" yaml:"name"`
+	Content string `json:"content" yaml:"content"`
 }
 
 type Count struct {


### PR DESCRIPTION
This updates the experimental jobspec to:

1. have one task (and rename to tasks). It didn't make sense to have a list and constrain it to 1. And a jobspec is a unit of work, if there are multiple pieces they would go into something that looks like a batch. I understand the development likely was anticipating some future of >1 tasks, but if it's been 8+ years and we aren't there, I think for an experimental design it's nice to remove that additional nested layer of the list.
2. add translation section 
3. do not require system 