### PR TITLE
feat: allow additional properties

### DIFF
--- a/pkg/jobspec/experimental/schema.json
+++ b/pkg/jobspec/experimental/schema.json
@@ -163,8 +163,7 @@
         "user": {
           "type": "object"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "task": {
       "description": "task configuration",


### PR DESCRIPTION
Problem: we should be able to provide additional, one off attributes
Solution: remove the boolean to not allow extra attribute properties.