### PR TITLE
feat: add functions to expose slots

### DIFF
--- a/examples/nextgen/v1/example1/example.go
+++ b/examples/nextgen/v1/example1/example.go
@@ -49,4 +49,17 @@ func main() {
 		os.Exit(1)
 	}
 	fmt.Println(string(out))
+
+	// Test getting slots
+	slots := js.GetSlots()
+	fmt.Printf("Found %d slots\n", len(slots))
+	for _, slot := range slots {
+		fmt.Println(slot)
+	}
+
+	slots = js.GetScheduledSlots()
+	fmt.Printf("Found %d scheduled slots\n", len(slots))
+	for _, slot := range slots {
+		fmt.Println(slot)
+	}
 }

--- a/examples/nextgen/v1/example1/jobspec.yaml
+++ b/examples/nextgen/v1/example1/jobspec.yaml
@@ -7,6 +7,7 @@ resources:
   mini-mummi:
     count: 8
     type: node
+    schedule: true
     with:
     - type: gpu
       count: 2
@@ -16,6 +17,7 @@ resources:
   mummi-gpu:
     count: 2
     type: node
+    schedule: true
     with:
     - type: gpu
       count: 1


### PR DESCRIPTION
Problem: we need to quickly get slots to schedule
Solution: provide functions to do so. If a jobspec resources does not define slots, all are considered to be slots. If the Jobspec does not define slots (or does) but some subset are marked for scheduling, filter to that set. Two different functions are provided to provide either.